### PR TITLE
Add SteelSeries Arctis headset HID backend and configuration

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -33,6 +33,6 @@ jobs:
       run: |
         $commit_ts=git show --no-patch --format=%at
         $commit_ds=(([System.DateTimeOffset]::FromUnixTimeSeconds($commit_ts)).DateTime).ToString("yyyyMMdd")
-        gh release create -R "jdrusso/LGSTrayBattery-nightly" `
+        gh release create -R "jdrusso/LGSTrayBattery" `
           $commit_ds `
           (get-item ./bin/Release/publish/*.zip)

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -33,6 +33,6 @@ jobs:
       run: |
         $commit_ts=git show --no-patch --format=%at
         $commit_ds=(([System.DateTimeOffset]::FromUnixTimeSeconds($commit_ts)).DateTime).ToString("yyyyMMdd")
-        gh release create -R "andyvorld/LGSTrayBattery-nightly" `
+        gh release create -R "jdrusso/LGSTrayBattery-nightly" `
           $commit_ds `
           (get-item ./bin/Release/publish/*.zip)

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: upload nightly build
       env:
-        GH_TOKEN: ${{ secrets.NIGHTLY_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         $commit_ts=git show --no-patch --format=%at
         $commit_ds=(([System.DateTimeOffset]::FromUnixTimeSeconds($commit_ts)).DateTime).ToString("yyyyMMdd")

--- a/LGSTrayCore/IServiceExtension.cs
+++ b/LGSTrayCore/IServiceExtension.cs
@@ -24,7 +24,7 @@ public static class IServiceExtension
         bool isEnabled = typeof(T) switch
         {
             { } when typeof(T) == typeof(GHubManager) => settings.GHub.Enabled,
-            { } when typeof(T) == typeof(LGSTrayHIDManager) => settings.Native.Enabled,
+            { } when typeof(T) == typeof(LGSTrayHIDManager) => (settings.Native.Enabled || settings.Arctis.Enabled),
             _ => false
         };
         if (!isEnabled) return;

--- a/LGSTrayHID/ArctisHidDevice.cs
+++ b/LGSTrayHID/ArctisHidDevice.cs
@@ -1,0 +1,93 @@
+using System.Runtime.InteropServices;
+using static LGSTrayHID.HidApi.HidApi;
+using LGSTrayHID.HidApi;
+using LGSTrayPrimitives;
+using LGSTrayPrimitives.MessageStructs;
+
+namespace LGSTrayHID;
+
+/* SteelSeries Arctis devices respond to an output report [0x00, 0xB0]
+   which returns an input report where byte 2 is battery level (0-4) and byte 3 indicates
+   charging status (0=disconnected, 1=charging, 3=discharging).
+   Reference: https://aarol.dev/posts/arctis-hid */
+
+internal sealed class ArctisHidDevice : IDisposable
+{
+    private readonly nint _handle;
+    private readonly string _identifier;
+    private readonly string _name;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _loop;
+
+    public unsafe ArctisHidDevice(HidDeviceInfo info)
+    {
+        _handle = HidOpenPath(ref info);
+        _identifier = info.GetPath();
+        _name = Marshal.PtrToStringUni((nint)info.ProductString) ?? "SteelSeries";
+
+        HidppManagerContext.Instance.SignalDeviceEvent(
+            IPCMessageType.INIT,
+            new InitMessage(_identifier, _name, true, DeviceType.Headset)
+        );
+
+        _loop = Task.Run(RunAsync);
+    }
+
+    private async Task RunAsync()
+    {
+        while (!_cts.IsCancellationRequested)
+        {
+            var (percent, status) = ReadBattery();
+            HidppManagerContext.Instance.SignalDeviceEvent(
+                IPCMessageType.UPDATE,
+                new UpdateMessage(_identifier, percent, status, 0, DateTimeOffset.Now)
+            );
+
+#if DEBUG
+            await Task.Delay(1000, _cts.Token);
+#else
+            await Task.Delay(GlobalSettings.settings.PollPeriod * 1000, _cts.Token);
+#endif
+        }
+    }
+
+    private (double, PowerSupplyStatus) ReadBattery()
+    {
+        byte[] cmd = [0x00, 0xB0];
+        _ = HidWrite(_handle, cmd, (nuint)cmd.Length);
+
+        byte[] buf = new byte[4];
+        int ret = HidReadTimeOut(_handle, buf, (nuint)buf.Length, 100);
+        if (ret < 4)
+        {
+            return (-1, PowerSupplyStatus.POWER_SUPPLY_STATUS_UNKNOWN);
+        }
+
+        double percent = buf[2] switch
+        {
+            0 => 0,
+            1 => 25,
+            2 => 50,
+            3 => 75,
+            4 => 100,
+            _ => -1,
+        };
+
+        PowerSupplyStatus status = buf[3] switch
+        {
+            1 => PowerSupplyStatus.POWER_SUPPLY_STATUS_CHARGING,
+            3 => PowerSupplyStatus.POWER_SUPPLY_STATUS_DISCHARGING,
+            _ => PowerSupplyStatus.POWER_SUPPLY_STATUS_NOT_CHARGING,
+        };
+
+        return (percent, status);
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _loop.Wait();
+        HidClose(_handle);
+        _cts.Dispose();
+    }
+}

--- a/LGSTrayHID/ArctisManagerService.cs
+++ b/LGSTrayHID/ArctisManagerService.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.Extensions.Hosting;
+using LGSTrayHID.HidApi;
+using static LGSTrayHID.HidApi.HidApi;
+
+namespace LGSTrayHID;
+
+public sealed class ArctisManagerService : IHostedService, IDisposable
+{
+    private readonly List<ArctisHidDevice> _devices = [];
+    private readonly CancellationTokenSource _cts = new();
+
+    private static readonly ushort VendorId = 0x1038;
+    private static readonly ushort[] ProductIds =
+    [
+        0x220e, // Arctis 7 Plus
+        0x2206, // Arctis Nova 7X
+        0x2258, // Arctis Nova 7X v2
+        0x220a, // Arctis Nova 7P
+        0x223a, // Arctis Nova 7 Diablo IV
+        0x2232, // Arctis Nova 5
+        0x2253, // Arctis Nova 5X
+    ];
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        EnumerateDevices();
+        return Task.CompletedTask;
+    }
+
+    private unsafe void EnumerateDevices()
+    {
+        HidDeviceInfo* devs = HidEnumerate(VendorId, 0);
+        for (var cur = devs; cur != null; cur = cur->Next)
+        {
+            if (!ProductIds.Contains(cur->ProductId)) continue;
+            if (cur->InterfaceNumber != 3) continue;
+            var info = *cur;
+            _devices.Add(new ArctisHidDevice(info));
+        }
+        HidFreeEnumeration(devs);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        foreach (var d in _devices)
+        {
+            d.Dispose();
+        }
+        _devices.Clear();
+        _cts.Dispose();
+    }
+}

--- a/LGSTrayHID/Program.cs
+++ b/LGSTrayHID/Program.cs
@@ -23,7 +23,14 @@ namespace LGSTrayHID
             GlobalSettings.settings = builder.Configuration.GetSection("Native")
                 .Get<NativeDeviceManagerSettings>() ?? GlobalSettings.settings;
 
+            var arctis = builder.Configuration.GetSection("Arctis").Get<IDeviceManagerSettings>();
+            bool arctisEnabled = arctis?.Enabled ?? false;
+
             builder.Services.AddLGSMessagePipe();
+            if (arctisEnabled)
+            {
+                builder.Services.AddHostedService<ArctisManagerService>();
+            }
             builder.Services.AddHostedService<HidppManagerService>();
 
             var host = builder.Build();

--- a/LGSTrayPrimitives/AppSettings.cs
+++ b/LGSTrayPrimitives/AppSettings.cs
@@ -9,6 +9,8 @@ public class AppSettings
     public IDeviceManagerSettings GHub { get; set; } = null!;
 
     public NativeDeviceManagerSettings Native { get; set; } = null!;
+
+    public IDeviceManagerSettings Arctis { get; set; } = null!;
 }
 
 public class UISettings

--- a/LGSTrayUI/Properties/Resources.Designer.cs
+++ b/LGSTrayUI/Properties/Resources.Designer.cs
@@ -130,6 +130,7 @@ namespace LGSTrayUI.Properties {
             }
         }
         
+
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>

--- a/LGSTrayUI/appsettings.toml
+++ b/LGSTrayUI/appsettings.toml
@@ -22,3 +22,5 @@ pollPeriod = 600
 # List of disabled devices
 disabledDevices = [
 ]
+[Arctis]
+enabled = true

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,9 @@ Please, visit [the latest release page](https://github.com/andyvorld/LGSTrayBatt
 - Migrated to using a `.toml` for appsettings
 
 ## Features
+### SteelSeries Arctis Support
+Monitor battery status of supported SteelSeries Arctis headsets via HID.
+
 ### Tray Indicator
 ![image](https://user-images.githubusercontent.com/24492062/138280300-6966b6a4-ff6d-46e6-9698-d2c8d612eb11.png)
 
@@ -32,7 +35,7 @@ Right-click for more options.
 ### Multiple Icons
 ![image](Assets/multi_icon.png)
 
-Depending on the number of devices selected in the context menu, multiple devices can be seen simultatniously
+Depending on the number of devices selected in the context menu, multiple devices can be seen simultaneously
 
 ### Numerical Icons
 ![image](Assets/numerical_icon.png)
@@ -90,10 +93,11 @@ Device ids starting with `dev` originates from tapping into Logitech GHUB's own 
 \*** - Logitech G Hub's metric of estimated life left on the battery
 
 ## HID++ Device Sources
-As of v3.0.0, there are 2 sources in which the program will pull battery status,
+As of v3.1.0, there are 3 sources in which the program will pull battery status,
 
 - Logitech G Hub via Websockets
 - Native HID, hidapi via PInvoke (Called "Native" in settings)
+- SteelSeries Arctis headsets via hidapi (Called "Arctis" in settings)
 
 These sources can be individually disabled/enabled before runtime via `appsettings.toml`, in the their respective sections,
 
@@ -102,6 +106,9 @@ These sources can be individually disabled/enabled before runtime via `appsettin
 enabled = true
 
 [Native]
+enabled = true
+
+[Arctis]
 enabled = true
 ```
 


### PR DESCRIPTION
## Summary
- add Arctis HID device and manager to poll SteelSeries headsets via hidapi
- expose new `[Arctis]` configuration and enable manager when set
- drop SteelSeries icon binaries and fall back to generic headset icon
- fix README typo

## Testing
- `dotnet build` *(command not found: dotnet)*
- `dotnet build LGSTrayHID/LGSTrayHID.csproj` *(command not found: dotnet)*
- `apt-get update` *(stalled while fetching package lists)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc24530dc8326b6eba6b945246c73